### PR TITLE
fix malformed json

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ curl -XPUT 'http://localhost:9200/_river/redisriver/_meta' -d '{
         "channels": "test-channel"
     },
     "index": {
-        "name": "test-redis",
+        "name": "test-redis"
     }
 }'
 ```


### PR DESCRIPTION
Removing (,) to avoid parsing errors:    

{"error":"MapperParsingException[failed to parse]; nested: JsonParseException[Unexpected character ('}' (code 125)): was expecting either valid name character (for unquoted name) or double-quote (for quoted) to start field name\n at [Source: [B@35e698; line: 1, column: 167]]; ","status":400}%
