### PR TITLE
fix Kotlin compiler warning about possible changes for scoping 

### DIFF
--- a/tribune-core/src/commonMain/kotlin/com/sksamuel/tribune/core/parser.kt
+++ b/tribune-core/src/commonMain/kotlin/com/sksamuel/tribune/core/parser.kt
@@ -36,6 +36,6 @@ fun interface Parser<in I, out A, out E> {
    fun parse(input: I): Validated<NonEmptyList<E>, A>
 
    fun <J> contramap(f: (J) -> I): Parser<J, A, E> =
-      Parser { this@Parser.parse(f(it)) }
+      Parser { parse(f(it)) }
 
 }


### PR DESCRIPTION
warning related to 'this@Parser'