### PR TITLE
Add to `Parser` functions `orElse()` & `orElseEither()`

### DIFF
--- a/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/parser.kt
+++ b/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/parser.kt
@@ -55,13 +55,14 @@ fun interface Parser<in I, out O, out E> {
 /**
  * Returns a new parser that first tries to parse the input with [this] and if it fails tries the [other].
  * If both parsers fail, errors are being accumulated
- * The two parsers have outputs [O] and [O2] that are related. In particalur, [O2] is supertype of [O]
+ * The two parsers have outputs [O] and [O2] that are related.
+ * In particular, [O2] is supertype of [O]
  */
 fun <I, E : E2, O : O2, I2 : I, E2, O2> Parser<I, O, E>.orElse(other: Parser<I2, O2, E2>): Parser<I2, O2, E2> =
    Parser { i ->
       parse(i).fold(
          ifRight = { it.right() },
-         ifLeft = { es -> other.parse(i).mapLeft { es2 -> (es as NonEmptyList<E2>) + es2 }}
+         ifLeft = { es -> other.parse(i).mapLeft { es2 -> (es as NonEmptyList<E2>) + es2 } }
       )
    }
 
@@ -69,8 +70,8 @@ fun <I, E : E2, O : O2, I2 : I, E2, O2> Parser<I, O, E>.orElse(other: Parser<I2,
  * Returns a new parser that first tries to parse the input with [this] and if it fails tries the [other].
  * The outputs of the two parsers, ([O] and [O2]) don't have to be related.
  * In case the first parser succeeds a left [O] is being returned
- * In case the second parser succeeds a ritht [O2] is being returned
+ * In case the second parser succeeds a right [O2] is being returned
  * If both parsers fail, errors are being accumulated
  */
-fun <I, E : E2, O , I2 : I, E2, O2> Parser<I,O,E>.orElseEither(other: Parser<I2,O2, E2>): Parser<I2, Either<O,O2>, E2> =
-   this.map { it.left() }.orElse( other.map { it.right() })
+fun <I, E : E2, O, I2 : I, E2, O2> Parser<I, O, E>.orElseEither(other: Parser<I2, O2, E2>): Parser<I2, Either<O, O2>, E2> =
+   this.map { it.left() }.orElse(other.map { it.right() })

--- a/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/parser.kt
+++ b/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/parser.kt
@@ -3,7 +3,7 @@ package com.sksamuel.tribune.core
 import arrow.core.*
 
 /**
- * A [Parser] is a function I => [EitherNel] that parses the input I, returing either
+ * A [Parser] is a function I => [EitherNel] that parses the input I, returning either
  * an output O or error E.
  *
  * It is implemented as an interface to allow for variance on the type parameters.
@@ -21,7 +21,7 @@ fun interface Parser<in I, out O, out E> {
        *
        * Eg:
        *
-       * Parser<String>() will return an identity parser that simply returns any intput string.
+       * Parser<String>() will return an identity parser that simply returns any input string.
        */
       operator fun <I> invoke(): Parser<I, I, Nothing> = Parser { it.right() }
 

--- a/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/SealedTests.kt
+++ b/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/SealedTests.kt
@@ -1,0 +1,82 @@
+package com.sksamuel.tribune.core
+
+import arrow.core.*
+import com.sksamuel.tribune.core.strings.match
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+sealed interface ProductCodeError {
+   data object NotWidgetCode : ProductCodeError
+   data object NotGizmoCode : ProductCodeError
+}
+
+sealed interface ProductCode {
+   val value: String
+
+   @JvmInline
+   value class GizmoCode private constructor(override val value: String) : ProductCode {
+      companion object {
+         private const val GIZMO_PATTERN = "\\AG\\d{3}\\z"
+         operator fun invoke(s: String): EitherNel<ProductCodeError.NotGizmoCode, GizmoCode> = parser.parse(s)
+
+         val parser: Parser<String, GizmoCode, ProductCodeError.NotGizmoCode> by lazy {
+            Parser<String>()
+               .match(Regex(GIZMO_PATTERN)) { ProductCodeError.NotGizmoCode }
+               .map { GizmoCode(it) }
+         }
+      }
+   }
+
+   @JvmInline
+   value class WidgetCode private constructor(override val value: String) : ProductCode {
+      companion object {
+         private const val WIDGET_PATTERN = "\\AW\\d{4}\\z"
+         operator fun invoke(s: String): EitherNel<ProductCodeError.NotWidgetCode, WidgetCode> = parser.parse(s)
+
+         val parser: Parser<String, WidgetCode, ProductCodeError.NotWidgetCode> by lazy {
+            Parser<String>()
+               .match(Regex(WIDGET_PATTERN)) { ProductCodeError.NotWidgetCode }
+               .map { WidgetCode(it) }
+         }
+      }
+   }
+
+   companion object {
+      operator fun invoke(s: String): EitherNel<ProductCodeError, ProductCode> = parser.parse(s)
+
+      val parser: Parser<String, ProductCode, ProductCodeError> = GizmoCode.parser.orElse(WidgetCode.parser)
+   }
+
+
+}
+
+class SealedTests : FunSpec() {
+   init {
+      test("GizmoCode success") {
+         val s = "G123"
+         ProductCode.GizmoCode(s).map { it.value } shouldBe s.right()
+      }
+
+      test("GizmoCode failure") {
+         ProductCode.GizmoCode("12342") shouldBe ProductCodeError.NotGizmoCode.nel().left()
+      }
+
+      test("WidgetCode success") {
+         val s = "W1234"
+         ProductCode.WidgetCode(s).map { it.value } shouldBe s.right()
+      }
+
+      test("WidgetCode failure") {
+         ProductCode.WidgetCode("12342") shouldBe ProductCodeError.NotWidgetCode.nel().left()
+      }
+
+      test("ProductCode success") {
+         ProductCode("W1234") shouldBe ProductCode.WidgetCode("W1234")
+         ProductCode("G123") shouldBe ProductCode.GizmoCode("G123")
+      }
+
+      test("ProductCode failure") {
+         ProductCode("1234") shouldBe nonEmptyListOf(ProductCodeError.NotGizmoCode, ProductCodeError.NotWidgetCode).left()
+      }
+   }
+}


### PR DESCRIPTION
This PR adds two new ways of combining two parsers.

`Parser.orElse(other)` 

This function combines two parsers by trying the first one and if it fails trying the other. This function  allows the combination of individual parsers for each member of a sealed hierarchy, thus producing a parser for a sum type.

`Parser.orElseEither(other)`

This is combines two parsers like `Parser.orElse()` but contrary to the `orElse()` case the two parser can produce unrelated outputs. Effectively, allows the combination of an two unrelated parsers (outcome wise) with an OR relationship.

