### PR TITLE
Upgrade ArrowKt to 2.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 buildscript {
    repositories {
       mavenCentral()
@@ -6,7 +8,7 @@ buildscript {
 }
 
 plugins {
-   kotlin("jvm").version("1.9.21")
+   kotlin("jvm").version("2.1.0")
    id("java-library")
    id("maven-publish")
    signing
@@ -26,19 +28,20 @@ allprojects {
    java {
       sourceCompatibility = JavaVersion.VERSION_11
    }
+
    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-      kotlinOptions {
-         jvmTarget = "11"
-         apiVersion = "1.9"
-         languageVersion = "1.9"
+      compilerOptions {
+         jvmTarget = JvmTarget.JVM_11
       }
    }
 
    tasks.withType<Test> {
       useJUnitPlatform()
+
       filter {
          isFailOnNoMatchingTests = false
       }
+
       testLogging {
          showExceptions = true
          showStandardStreams = true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
          library("ktor-client-content-negotiation", "io.ktor:ktor-client-content-negotiation:$ktor")
          library("ktor-serialization-jackson", "io.ktor:ktor-serialization-jackson:$ktor")
 
-         library("arrow-core", "io.arrow-kt:arrow-core:1.2.1")
+         library("arrow-core", "io.arrow-kt:arrow-core:2.0.0")
          library("spring-boot-starter-web", "org.springframework.boot:spring-boot-starter-web:2.7.12")
 
          val kotest = "5.8.0"

--- a/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/compose.kt
+++ b/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/compose.kt
@@ -80,20 +80,3 @@ fun <INPUT, OUTPUT, A, B, C, D, E, F, G, H, I, ERROR> Parser.Companion.compose(
    zip(p1, p2, p3, p4, p5, p6, p7, p8, p9).map { (a, b, c, d, e, f, g, h, i) ->
       f(a, b, c, d, e, f, g, h, i)
    }
-
-fun <INPUT, OUTPUT, A, B, C, D, E, F, G, H, I, J, ERROR> Parser.Companion.compose(
-   p1: Parser<INPUT, A, ERROR>,
-   p2: Parser<INPUT, B, ERROR>,
-   p3: Parser<INPUT, C, ERROR>,
-   p4: Parser<INPUT, D, ERROR>,
-   p5: Parser<INPUT, E, ERROR>,
-   p6: Parser<INPUT, F, ERROR>,
-   p7: Parser<INPUT, G, ERROR>,
-   p8: Parser<INPUT, H, ERROR>,
-   p9: Parser<INPUT, I, ERROR>,
-   p10: Parser<INPUT, J, ERROR>,
-   f: (A, B, C, D, E, F, G, H, I, J) -> OUTPUT,
-): Parser<INPUT, OUTPUT, ERROR> =
-   zip(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10).map { (a, b, c, d, e, f, g, h, i, j) ->
-      f(a, b, c, d, e, f, g, h, i, j)
-   }

--- a/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/maps/maps.kt
+++ b/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/maps/maps.kt
@@ -1,17 +1,17 @@
 package com.sksamuel.tribune.core.maps
 
-import arrow.core.sequence
+import arrow.core.raise.either
 import com.sksamuel.tribune.core.Parser
 import com.sksamuel.tribune.core.transformEither
 
 fun <I, K, V, R, E> Parser<I, Map<K, V>, E>.parseKeys(parser: Parser<K, R, E>): Parser<I, Map<R, V>, E> {
     return this.transformEither { input ->
-        input.map { (key, value) -> parser.parse(key).map { Pair(it, value) } }.sequence().map { it.toMap() }
+        either { input.map { (key, value) -> Pair(parser.parse(key).bind(), value) }.toMap() }
     }
 }
 
 fun <I, K, V, R, E> Parser<I, Map<K, V>, E>.parseValues(parser: Parser<V, R, E>): Parser<I, Map<K, R>, E> {
     return this.transformEither { input ->
-        input.map { (key, value) -> parser.parse(value).map { Pair(key, it) } }.sequence().map { it.toMap() }
+        either { input.map { (key, value) -> Pair(key, parser.parse(value).bind()) }.toMap() }
     }
 }

--- a/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/zip.kt
+++ b/tribune-core/src/main/kotlin/com/sksamuel/tribune/core/zip.kt
@@ -1,7 +1,6 @@
 package com.sksamuel.tribune.core
 
 import arrow.core.Either
-import arrow.core.Tuple10
 import arrow.core.Tuple4
 import arrow.core.Tuple5
 import arrow.core.Tuple6
@@ -147,33 +146,5 @@ fun <INPUT, A, B, C, D, E, F, G, H, I, ERROR> Parser.Companion.zip(
       p9.parse(input),
    ) { a, b, c, d, e, f, g, h, i ->
       Tuple9(a, b, c, d, e, f, g, h, i)
-   }
-}
-
-fun <INPUT, A, B, C, D, E, F, G, H, I, J, ERROR> Parser.Companion.zip(
-   p1: Parser<INPUT, A, ERROR>,
-   p2: Parser<INPUT, B, ERROR>,
-   p3: Parser<INPUT, C, ERROR>,
-   p4: Parser<INPUT, D, ERROR>,
-   p5: Parser<INPUT, E, ERROR>,
-   p6: Parser<INPUT, F, ERROR>,
-   p7: Parser<INPUT, G, ERROR>,
-   p8: Parser<INPUT, H, ERROR>,
-   p9: Parser<INPUT, I, ERROR>,
-   p10: Parser<INPUT, J, ERROR>,
-): Parser<INPUT, Tuple10<A, B, C, D, E, F, G, H, I, J>, ERROR> = Parser { input ->
-   Either.zipOrAccumulate(
-      p1.parse(input),
-      p2.parse(input),
-      p3.parse(input),
-      p4.parse(input),
-      p5.parse(input),
-      p6.parse(input),
-      p7.parse(input),
-      p8.parse(input),
-      p9.parse(input),
-      p10.parse(input),
-   ) { a, b, c, d, e, f, g, h, i, j ->
-      Tuple10(a, b, c, d, e, f, g, h, i, j)
    }
 }

--- a/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/collections/MapTest.kt
+++ b/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/collections/MapTest.kt
@@ -1,4 +1,39 @@
 package com.sksamuel.tribune.core.collections
 
-class MapTest {
+import com.sksamuel.tribune.core.Parser
+import com.sksamuel.tribune.core.map
+import com.sksamuel.tribune.core.maps.parseKeys
+import com.sksamuel.tribune.core.maps.parseValues
+import com.sksamuel.tribune.core.strings.minlen
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MapTest : FunSpec() {
+    init {
+        data class ParsedString(val str: String)
+
+        test("parseKeys") {
+            val p = Parser<String>().map { ParsedString(it) }
+            val pmap = Parser.from<Map<String, String>>().parseKeys(p)
+            pmap.parse(mapOf("a" to "b", "c" to "d")).getOrNull() shouldBe mapOf(ParsedString("a") to "b", ParsedString("c") to "d")
+        }
+
+        test("parseKeys should short-circuit errors") {
+            val p = Parser<String>().minlen(2) { "whack $it" }.map { ParsedString(it) }
+            val pmap = Parser.from<Map<String, String>>().parseKeys(p)
+            pmap.parse(mapOf("a" to "b", "c" to "d")).leftOrNull() shouldBe listOf("whack a")
+        }
+
+        test("parseValues") {
+            val p = Parser<String>().map { ParsedString(it) }
+            val pmap = Parser.from<Map<String, String>>().parseValues(p)
+            pmap.parse(mapOf("a" to "b", "c" to "d")).getOrNull() shouldBe mapOf("a" to ParsedString("b"), "c" to ParsedString("d"))
+        }
+
+        test("parseValues should short-circuit errors") {
+            val p = Parser<String>().minlen(2) { "whack $it" }.map { ParsedString(it) }
+            val pmap = Parser.from<Map<String, String>>().parseValues(p)
+            pmap.parse(mapOf("a" to "b", "c" to "d")).leftOrNull() shouldBe listOf("whack b")
+        }
+    }
 }

--- a/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/collections/MapTest.kt
+++ b/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/collections/MapTest.kt
@@ -1,0 +1,4 @@
+package com.sksamuel.tribune.core.collections
+
+class MapTest {
+}

--- a/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/utils.kt
+++ b/tribune-core/src/test/kotlin/com/sksamuel/tribune/core/utils.kt
@@ -1,8 +1,0 @@
-package com.sksamuel.tribune.core
-
-import arrow.core.NonEmptyList
-import arrow.core.ValidatedNel
-
-// helper functions for validated
-fun <E, A> ValidatedNel<E, A>.getOrThrow(): A = fold({ error(it) }, { it })
-fun <E, A> ValidatedNel<E, A>.getErrorsOrThrow(): NonEmptyList<E> = fold({ it }, { error(it.toString()) })


### PR DESCRIPTION
### Description
- Upgrade Kotlin to 2.1.0
    - Replaced deprecated `kotlinOptions` with `compilerOptions`
- Upgrade ArrowKt to 2.0.0
    - Removed any code using `Tuple10` and `ValidatedNel`, as they're no longer available
    - Replaced deprecated `.sequence()` with `either` and `.bind()`
    - Add unit tests for map operations